### PR TITLE
Use latest RenderMap type from renderers-core

### DIFF
--- a/.changeset/wicked-needles-thank.md
+++ b/.changeset/wicked-needles-thank.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+Use latest RenderMap type from renderers-core

--- a/package.json
+++ b/package.json
@@ -41,15 +41,15 @@
         "test:unit": "vitest run"
     },
     "dependencies": {
-        "@codama/errors": "^1.3.7",
-        "@codama/nodes": "^1.3.7",
-        "@codama/renderers-core": "^1.2.2",
-        "@codama/visitors-core": "^1.3.7",
+        "@codama/errors": "^1.4.1",
+        "@codama/nodes": "^1.4.1",
+        "@codama/renderers-core": "^1.3.0",
+        "@codama/visitors-core": "^1.4.1",
         "@solana/codecs-strings": "^5.0.0",
         "nunjucks": "^3.2.4"
     },
     "devDependencies": {
-        "@codama/nodes-from-anchor": "^1.2.9",
+        "@codama/nodes-from-anchor": "^1.3.3",
         "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.29.7",
         "@solana/eslint-config-solana": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,16 +9,16 @@ importers:
   .:
     dependencies:
       '@codama/errors':
-        specifier: ^1.3.7
+        specifier: ^1.4.1
         version: 1.4.1
       '@codama/nodes':
-        specifier: ^1.3.7
+        specifier: ^1.4.1
         version: 1.4.1
       '@codama/renderers-core':
-        specifier: ^1.2.2
-        version: 1.2.5
+        specifier: ^1.3.0
+        version: 1.3.0
       '@codama/visitors-core':
-        specifier: ^1.3.7
+        specifier: ^1.4.1
         version: 1.4.1
       '@solana/codecs-strings':
         specifier: ^5.0.0
@@ -34,8 +34,8 @@ importers:
         specifier: ^2.29.7
         version: 2.29.7(@types/node@24.10.1)
       '@codama/nodes-from-anchor':
-        specifier: ^1.2.9
-        version: 1.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: ^1.3.3
+        version: 1.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/eslint-config-solana':
         specifier: ^5.0.0
         version: 5.0.0(@eslint/js@9.39.1)(@types/eslint__js@8.42.3)(eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(jest@30.1.3(@types/node@24.10.1))(typescript@5.9.3))(eslint-plugin-react-hooks@5.2.0(eslint@9.39.1))(eslint-plugin-simple-import-sort@12.1.1(eslint@9.39.1))(eslint-plugin-sort-keys-fix@1.1.2)(eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.43.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(globals@14.0.0)(jest@30.1.3(@types/node@24.10.1))(typescript-eslint@8.43.0(eslint@9.39.1)(typescript@5.9.3))(typescript@5.9.3)
@@ -312,14 +312,14 @@ packages:
   '@codama/node-types@1.4.1':
     resolution: {integrity: sha512-eqPKI1pZR+xaYHytMQUhW+DHmmhLhzVNTN9Cs+VpJV4NArJBrmx3Yht39tjT9Ul7eS9jGmBO1lodFxSCRKV4sQ==}
 
-  '@codama/nodes-from-anchor@1.3.1':
-    resolution: {integrity: sha512-PTpSn6pmAReb1d9uzyzvCC6xjcC/W3KJ2jNIIfJkaMYyx0sE2o6OP0Ql3Du130TzSd7SpPVGj0MS8EyINq+GUA==}
+  '@codama/nodes-from-anchor@1.3.3':
+    resolution: {integrity: sha512-PjnpYddndQABPFoslEyiygGapl0UlFh8Ng5o0HKmb7WvrEaTN0gqTP5Za/fNT3Kf7PUrafF85vKS6UMaYAhLpQ==}
 
   '@codama/nodes@1.4.1':
     resolution: {integrity: sha512-gqr87Neh3g0+0nubVC3j4JNT99xC4flv72Z8Yjplz5vxoU+IncE3Rsv3mr8V1AC0k8fv5/ND21OcSOK44Wbh2g==}
 
-  '@codama/renderers-core@1.2.5':
-    resolution: {integrity: sha512-MJ+PjUSalPuperZFeH9t7vNY/HXUv0QfVjVAIvi+Z4ey51hLPyzSLg4IYq96hYvLpTomMp4socpVecKoyOgzrA==}
+  '@codama/renderers-core@1.3.0':
+    resolution: {integrity: sha512-39ugOM7c6AT5h6azC8lix6YGA17u8wSsCzJbDrShTzRgz+QHWVF1Uci/v4CEcesEHgGQigP6f1jGAnEoTb/gcQ==}
 
   '@codama/visitors-core@1.4.1':
     resolution: {integrity: sha512-1IzVQlr4gxv4QQcZE98NZqTS2QLH3FdXzPvIi3Y9o34zyS9cCgdif5/nGAd1Q35uVQJSTV5UcIJ/a0dWqLNaFg==}
@@ -3572,7 +3572,7 @@ snapshots:
 
   '@codama/node-types@1.4.1': {}
 
-  '@codama/nodes-from-anchor@1.3.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@codama/nodes-from-anchor@1.3.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@codama/errors': 1.4.1
       '@codama/nodes': 1.4.1
@@ -3588,7 +3588,7 @@ snapshots:
       '@codama/errors': 1.4.1
       '@codama/node-types': 1.4.1
 
-  '@codama/renderers-core@1.2.5':
+  '@codama/renderers-core@1.3.0':
     dependencies:
       '@codama/errors': 1.4.1
       '@codama/nodes': 1.4.1

--- a/src/getRenderMapVisitor.ts
+++ b/src/getRenderMapVisitor.ts
@@ -113,9 +113,8 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                         imports.mergeWith(seedsImports);
                     }
 
-                    return createRenderMap(
-                        `accounts/${snakeCase(node.name)}.rs`,
-                        render('accountsPage.njk', {
+                    return createRenderMap(`accounts/${snakeCase(node.name)}.rs`, {
+                        content: render('accountsPage.njk', {
                             account: node,
                             anchorTraits,
                             constantSeeds,
@@ -130,21 +129,20 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                             seeds,
                             typeManifest,
                         }),
-                    );
+                    });
                 },
 
                 visitDefinedType(node) {
                     const typeManifest = visit(node, typeManifestVisitor);
                     const imports = new ImportMap().mergeWithManifest(typeManifest);
 
-                    return createRenderMap(
-                        `types/${snakeCase(node.name)}.rs`,
-                        render('definedTypesPage.njk', {
+                    return createRenderMap(`types/${snakeCase(node.name)}.rs`, {
+                        content: render('definedTypesPage.njk', {
                             definedType: node,
                             imports: imports.remove(`generatedTypes::${pascalCase(node.name)}`).toString(dependencyMap),
                             typeManifest,
                         }),
-                    );
+                    });
                 },
 
                 visitInstruction(node) {
@@ -235,9 +233,8 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                     const dataTraits = getTraitsFromNode(node);
                     imports.mergeWith(dataTraits.imports);
 
-                    return createRenderMap(
-                        `instructions/${snakeCase(node.name)}.rs`,
-                        render('instructionsPage.njk', {
+                    return createRenderMap(`instructions/${snakeCase(node.name)}.rs`, {
+                        content: render('instructionsPage.njk', {
                             dataTraits: dataTraits.render,
                             discriminatorConstants: discriminatorConstants.render,
                             hasArgs,
@@ -251,7 +248,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                             program,
                             typeManifest,
                         }),
-                    );
+                    });
                 },
 
                 visitProgram(node, { self }) {
@@ -266,15 +263,13 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
 
                     // Errors.
                     if (node.errors.length > 0) {
-                        renders = addToRenderMap(
-                            renders,
-                            `errors/${snakeCase(node.name)}.rs`,
-                            render('errorsPage.njk', {
+                        renders = addToRenderMap(renders, `errors/${snakeCase(node.name)}.rs`, {
+                            content: render('errorsPage.njk', {
                                 errors: node.errors,
                                 imports: new ImportMap().toString(dependencyMap),
                                 program: node,
                             }),
-                        );
+                        });
                     }
 
                     program = null;
@@ -306,15 +301,22 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                     return mergeRenderMaps([
                         createRenderMap({
                             ['accounts/mod.rs']:
-                                accountsToExport.length > 0 ? render('accountsMod.njk', ctx) : undefined,
-                            ['errors/mod.rs']: programsToExport.length > 0 ? render('errorsMod.njk', ctx) : undefined,
+                                accountsToExport.length > 0 ? { content: render('accountsMod.njk', ctx) } : undefined,
+                            ['errors/mod.rs']:
+                                programsToExport.length > 0 ? { content: render('errorsMod.njk', ctx) } : undefined,
                             ['instructions/mod.rs']:
-                                instructionsToExport.length > 0 ? render('instructionsMod.njk', ctx) : undefined,
-                            ['mod.rs']: render('rootMod.njk', ctx),
-                            ['programs.rs']: programsToExport.length > 0 ? render('programsMod.njk', ctx) : undefined,
-                            ['shared.rs']: accountsToExport.length > 0 ? render('sharedPage.njk', ctx) : undefined,
+                                instructionsToExport.length > 0
+                                    ? { content: render('instructionsMod.njk', ctx) }
+                                    : undefined,
+                            ['mod.rs']: { content: render('rootMod.njk', ctx) },
+                            ['programs.rs']:
+                                programsToExport.length > 0 ? { content: render('programsMod.njk', ctx) } : undefined,
+                            ['shared.rs']:
+                                accountsToExport.length > 0 ? { content: render('sharedPage.njk', ctx) } : undefined,
                             ['types/mod.rs']:
-                                definedTypesToExport.length > 0 ? render('definedTypesMod.njk', ctx) : undefined,
+                                definedTypesToExport.length > 0
+                                    ? { content: render('definedTypesMod.njk', ctx) }
+                                    : undefined,
                         }),
                         ...getAllPrograms(node).map(p => visit(p, self)),
                     ]);

--- a/test/accountsPage.test.ts
+++ b/test/accountsPage.test.ts
@@ -45,7 +45,7 @@ test('it renders a byte array seed used on an account', () => {
 
     // Then we expect the following identifier and reference to the byte array
     // as a parameters to be rendered.
-    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs').content, [
         `byte_array_seed: [u8; 32],`,
         `&byte_array_seed,`,
     ]);
@@ -74,7 +74,7 @@ test('it renders an empty array of seeds for seedless PDAs', () => {
 
     // Then we expect the following identifier and reference to the byte array
     // as a parameters to be rendered.
-    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs'), [/pub fn find_pda\(/, /&\[\s*\]/]);
+    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs').content, [/pub fn find_pda\(/, /&\[\s*\]/]);
 });
 
 test('it renders constant PDA seeds as prefix consts', () => {
@@ -99,7 +99,7 @@ test('it renders constant PDA seeds as prefix consts', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following const helpers for constant seeds.
-    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs').content, [
         '///   0. `TestAccount::PREFIX.0`',
         '///   1. my_account (`Pubkey`)',
         '///   2. `TestAccount::PREFIX.1`',
@@ -131,7 +131,7 @@ test('it renders anchor traits impl', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following Anchor traits impl.
-    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs').content, [
         '#[cfg(feature = "anchor")]',
         'impl anchor_lang::AccountDeserialize for TestAccount',
         'impl anchor_lang::AccountSerialize for TestAccount {}',
@@ -163,7 +163,7 @@ test('it renders fetch functions', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following fetch functions to be rendered.
-    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs').content, [
         'pub fn fetch_test_account',
         'pub fn fetch_maybe_test_account',
         'pub fn fetch_all_test_account',
@@ -195,7 +195,7 @@ test('it renders account without anchor traits', () => {
     const renderMap = visit(node, getRenderMapVisitor({ anchorTraits: false }));
 
     // Then we do not expect Anchor traits.
-    codeDoesNotContains(getFromRenderMap(renderMap, 'accounts/test_account.rs'), [
+    codeDoesNotContains(getFromRenderMap(renderMap, 'accounts/test_account.rs').content, [
         '#[cfg(feature = "anchor")]',
         '#[cfg(feature = "anchor-idl-build")]',
     ]);

--- a/test/definedTypesPage.test.ts
+++ b/test/definedTypesPage.test.ts
@@ -39,7 +39,7 @@ test('it renders a prefix string on a defined type', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following use and identifier to be rendered.
-    codeContains(getFromRenderMap(renderMap, 'types/blob.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'types/blob.rs').content, [
         `use kaigan::types::U8PrefixString;`,
         `content_type: U8PrefixString,`,
     ]);
@@ -62,7 +62,7 @@ test('it renders a scalar enum with Copy derive', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following use and identifier to be rendered.
-    codeContains(getFromRenderMap(renderMap, 'types/tag.rs'), [`#[derive(`, `Copy`, `pub enum Tag`]);
+    codeContains(getFromRenderMap(renderMap, 'types/tag.rs').content, [`#[derive(`, `Copy`, `pub enum Tag`]);
 });
 
 test('it renders a non-scalar enum without Copy derive', () => {
@@ -93,7 +93,10 @@ test('it renders a non-scalar enum without Copy derive', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following use and identifier to be rendered.
-    codeContains(getFromRenderMap(renderMap, 'types/tag_with_struct.rs'), [`#[derive(`, `pub enum TagWithStruct`]);
+    codeContains(getFromRenderMap(renderMap, 'types/tag_with_struct.rs').content, [
+        `#[derive(`,
+        `pub enum TagWithStruct`,
+    ]);
     // And we expect the Copy derive to be missing.
-    codeDoesNotContains(getFromRenderMap(renderMap, 'types/tag_with_struct.rs'), `Copy`);
+    codeDoesNotContains(getFromRenderMap(renderMap, 'types/tag_with_struct.rs').content, `Copy`);
 });

--- a/test/errorsPage.test.ts
+++ b/test/errorsPage.test.ts
@@ -29,7 +29,7 @@ test('it renders codes for errors', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following errors with codes.
-    codeContains(getFromRenderMap(renderMap, 'errors/spl_token.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'errors/spl_token.rs').content, [
         `InvalidInstruction = 0x1770,`,
         `InvalidProgram = 0x1B58,`,
     ]);

--- a/test/instructionsPage.test.ts
+++ b/test/instructionsPage.test.ts
@@ -18,7 +18,7 @@ test('it renders a public instruction data struct', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following pub struct.
-    codeContains(getFromRenderMap(renderMap, 'instructions/mint_tokens.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'instructions/mint_tokens.rs').content, [
         `pub struct MintTokensInstructionData`,
         `pub fn new(`,
     ]);
@@ -46,7 +46,7 @@ test('it renders an instruction with a remainder str', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following pub struct.
-    codeContains(getFromRenderMap(renderMap, 'instructions/add_memo.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'instructions/add_memo.rs').content, [
         `use kaigan::types::RemainderStr`,
         `pub memo: RemainderStr`,
     ]);
@@ -64,7 +64,7 @@ test('it renders a default impl for instruction data struct', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect the following Default trait to be implemented.
-    codeContains(getFromRenderMap(renderMap, 'instructions/mint_tokens.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'instructions/mint_tokens.rs').content, [
         `impl Default for MintTokensInstructionData`,
         `fn default(`,
     ]);

--- a/test/types/array.test.ts
+++ b/test/types/array.test.ts
@@ -25,12 +25,12 @@ test('it exports short vecs', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect a short vec to be exported.
-    codeContains(getFromRenderMap(renderMap, 'types/my_short_vec.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'types/my_short_vec.rs').content, [
         /pub type MyShortVec = ShortVec<Pubkey>;/,
         /use solana_pubkey::Pubkey/,
         /use solana_short_vec::ShortVec/,
     ]);
-    codeDoesNotContains(getFromRenderMap(renderMap, 'types/my_short_vec.rs'), [
+    codeDoesNotContains(getFromRenderMap(renderMap, 'types/my_short_vec.rs').content, [
         /use borsh::BorshSerialize/,
         /use borsh::BorshDeserialize/,
     ]);
@@ -52,7 +52,7 @@ test('it exports short vecs as struct fields', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect a short vec to be exported as a struct field.
-    codeContains(getFromRenderMap(renderMap, 'types/my_short_vec.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'types/my_short_vec.rs').content, [
         /pub value: ShortVec<Pubkey>,/,
         /use solana_pubkey::Pubkey/,
         /use solana_short_vec::ShortVec/,

--- a/test/types/number.test.ts
+++ b/test/types/number.test.ts
@@ -17,11 +17,11 @@ test('it exports short u16 numbers', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect a short u16 to be exported.
-    codeContains(getFromRenderMap(renderMap, 'types/my_short_u16.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'types/my_short_u16.rs').content, [
         /pub type MyShortU16 = ShortU16/,
         /use solana_short_vec::ShortU16/,
     ]);
-    codeDoesNotContains(getFromRenderMap(renderMap, 'types/my_short_u16.rs'), [
+    codeDoesNotContains(getFromRenderMap(renderMap, 'types/my_short_u16.rs').content, [
         /use borsh::BorshSerialize/,
         /use borsh::BorshDeserialize/,
     ]);
@@ -38,7 +38,7 @@ test('it exports short u16 numbers as struct fields', () => {
     const renderMap = visit(node, getRenderMapVisitor());
 
     // Then we expect a short u16 to be exported as a struct field.
-    codeContains(getFromRenderMap(renderMap, 'types/my_short_u16.rs'), [
+    codeContains(getFromRenderMap(renderMap, 'types/my_short_u16.rs').content, [
         /pub value: ShortU16/,
         /use solana_short_vec::ShortU16/,
     ]);

--- a/test/utils/traitOptions.test.ts
+++ b/test/utils/traitOptions.test.ts
@@ -19,6 +19,7 @@ import {
     structFieldTypeNode,
     structTypeNode,
 } from '@codama/nodes';
+import { getFromRenderMap } from '@codama/renderers-core';
 import { visit } from '@codama/visitors-core';
 import { describe, expect, test } from 'vitest';
 
@@ -384,7 +385,7 @@ describe('conditional try_to_vec generation', () => {
         );
 
         // Then we expect the try_to_vec method to be included with borsh::to_vec implementation.
-        const instruction = renderMap.get('instructions/transfer.rs') as string;
+        const instruction = getFromRenderMap(renderMap, 'instructions/transfer.rs').content;
         expect(instruction).toContain('pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error>');
         expect(instruction).toContain('borsh::to_vec(self)');
 
@@ -407,7 +408,7 @@ describe('conditional try_to_vec generation', () => {
         );
 
         // Then we expect no try_to_vec method and no borsh::to_vec calls.
-        const instruction = renderMap.get('instructions/transfer.rs') as string;
+        const instruction = getFromRenderMap(renderMap, 'instructions/transfer.rs').content;
         expect(instruction).not.toContain('pub(crate) fn try_to_vec(&self)');
         expect(instruction).not.toContain('borsh::to_vec');
 
@@ -432,7 +433,7 @@ describe('conditional try_to_vec generation', () => {
         );
 
         // Then we expect try_to_vec to be included for both InstructionData and InstructionArgs.
-        const instruction = renderMap.get('instructions/transfer.rs') as string;
+        const instruction = getFromRenderMap(renderMap, 'instructions/transfer.rs').content;
         expect(instruction).toMatch(/impl TransferInstructionData \{[\s\S]*?pub\(crate\) fn try_to_vec/);
         expect(instruction).toMatch(/impl TransferInstructionArgs \{[\s\S]*?pub\(crate\) fn try_to_vec/);
 
@@ -456,7 +457,7 @@ describe('conditional try_to_vec generation', () => {
         );
 
         // Then we expect try_to_vec to be generated even with fully qualified trait name.
-        const instruction = renderMap.get('instructions/transfer.rs') as string;
+        const instruction = getFromRenderMap(renderMap, 'instructions/transfer.rs').content;
         expect(instruction).toContain('pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error>');
         expect(instruction).toContain('borsh::to_vec(self)');
         expect(instruction).toContain('#[derive(borsh::BorshSerialize');
@@ -480,7 +481,7 @@ describe('conditional try_to_vec generation', () => {
         );
 
         // Then we expect the try_to_vec method to be omitted and no borsh::to_vec calls.
-        const instruction = renderMap.get('instructions/transfer.rs') as string;
+        const instruction = getFromRenderMap(renderMap, 'instructions/transfer.rs').content;
         expect(instruction).not.toContain('pub(crate) fn try_to_vec(&self)');
         expect(instruction).not.toContain('borsh::to_vec');
         expect(instruction).toContain('#[derive(Clone, Debug)]');
@@ -508,7 +509,7 @@ describe('conditional serde field attributes', () => {
         );
 
         // Then we expect field attributes to be wrapped in cfg_attr.
-        const account = renderMap.get('accounts/my_account.rs') as string;
+        const account = getFromRenderMap(renderMap, 'accounts/my_account.rs').content;
         expect(account).toContain(
             '#[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::DisplayFromStr>"))]',
         );
@@ -551,7 +552,7 @@ describe('conditional serde field attributes', () => {
         );
 
         // Then we expect field attributes without cfg_attr.
-        const account = renderMap.get('accounts/my_account.rs') as string;
+        const account = getFromRenderMap(renderMap, 'accounts/my_account.rs').content;
         expect(account).toContain('#[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]');
         expect(account).toContain('#[serde(with = "serde_with::As::<Vec<serde_with::DisplayFromStr>>")]');
         expect(account).not.toContain('#[cfg_attr(feature = "serde"');
@@ -582,7 +583,7 @@ describe('conditional serde field attributes', () => {
         );
 
         // Then we expect no serde field attributes at all.
-        const account = renderMap.get('accounts/my_account.rs') as string;
+        const account = getFromRenderMap(renderMap, 'accounts/my_account.rs').content;
         expect(account).not.toContain('serde(with');
         expect(account).not.toContain('serde_with::As');
         expect(account).not.toContain('DisplayFromStr');
@@ -607,7 +608,7 @@ describe('conditional serde field attributes', () => {
         );
 
         // Then we expect the big array attribute to be feature-flagged.
-        const account = renderMap.get('accounts/my_account.rs') as string;
+        const account = getFromRenderMap(renderMap, 'accounts/my_account.rs').content;
         expect(account).toContain('#[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]');
     });
 
@@ -635,7 +636,7 @@ describe('conditional serde field attributes', () => {
         );
 
         // Then we expect the bytes attribute without cfg_attr.
-        const account = renderMap.get('accounts/my_account.rs') as string;
+        const account = getFromRenderMap(renderMap, 'accounts/my_account.rs').content;
         expect(account).toContain('#[serde(with = "serde_with::As::<serde_with::Bytes>")]');
         expect(account).not.toContain('#[cfg_attr(feature = "serde"');
     });
@@ -661,7 +662,7 @@ describe('conditional serde field attributes', () => {
         );
 
         // Then we expect field attributes with the custom feature name.
-        const account = renderMap.get('accounts/my_account.rs') as string;
+        const account = getFromRenderMap(renderMap, 'accounts/my_account.rs').content;
         expect(account).toContain(
             '#[cfg_attr(feature = "json_support", serde(with = "serde_with::As::<serde_with::DisplayFromStr>"))]',
         );
@@ -690,7 +691,7 @@ describe('conditional serde field attributes', () => {
         );
 
         // Then we expect field attributes without cfg_attr since override has serde but no feature flag.
-        const account = renderMap.get('accounts/my_account.rs') as string;
+        const account = getFromRenderMap(renderMap, 'accounts/my_account.rs').content;
         expect(account).toContain('#[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]');
         expect(account).not.toContain('#[cfg_attr(feature = "serde"');
     });


### PR DESCRIPTION
This PR bumps the `renderers-core` package and updates the use of `RenderMaps` to its latest definition.