### PR TITLE
fixup! fix remaining accounts is_writable, is_signer order when invoke

### DIFF
--- a/.changeset/dry-moles-notice.md
+++ b/.changeset/dry-moles-notice.md
@@ -1,0 +1,5 @@
+---
+"@codama/renderers-rust": patch
+---
+
+Fix remaining accounts is_writable, is_signer order when invoke

--- a/e2e/anchor/src/generated/instructions/create_guard.rs
+++ b/e2e/anchor/src/generated/instructions/create_guard.rs
@@ -401,8 +401,8 @@ impl<'a, 'b> CreateGuardCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = CreateGuardInstructionData::new().try_to_vec().unwrap();

--- a/e2e/anchor/src/generated/instructions/execute.rs
+++ b/e2e/anchor/src/generated/instructions/execute.rs
@@ -339,8 +339,8 @@ impl<'a, 'b> ExecuteCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = ExecuteInstructionData::new().try_to_vec().unwrap();

--- a/e2e/anchor/src/generated/instructions/initialize.rs
+++ b/e2e/anchor/src/generated/instructions/initialize.rs
@@ -282,8 +282,8 @@ impl<'a, 'b> InitializeCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = InitializeInstructionData::new().try_to_vec().unwrap();

--- a/e2e/anchor/src/generated/instructions/update_guard.rs
+++ b/e2e/anchor/src/generated/instructions/update_guard.rs
@@ -334,8 +334,8 @@ impl<'a, 'b> UpdateGuardCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = UpdateGuardInstructionData::new().try_to_vec().unwrap();

--- a/e2e/dummy/src/generated/instructions/instruction1.rs
+++ b/e2e/dummy/src/generated/instructions/instruction1.rs
@@ -127,8 +127,8 @@ impl<'a, 'b> Instruction1Cpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = Instruction1InstructionData::new().try_to_vec().unwrap();

--- a/e2e/dummy/src/generated/instructions/instruction2.rs
+++ b/e2e/dummy/src/generated/instructions/instruction2.rs
@@ -127,8 +127,8 @@ impl<'a, 'b> Instruction2Cpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = Instruction2InstructionData::new().try_to_vec().unwrap();

--- a/e2e/dummy/src/generated/instructions/instruction3.rs
+++ b/e2e/dummy/src/generated/instructions/instruction3.rs
@@ -131,8 +131,8 @@ impl<'a, 'b> Instruction3Cpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = Instruction3InstructionData::new().try_to_vec().unwrap();

--- a/e2e/dummy/src/generated/instructions/instruction4.rs
+++ b/e2e/dummy/src/generated/instructions/instruction4.rs
@@ -162,8 +162,8 @@ impl<'a, 'b> Instruction4Cpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = Instruction4InstructionData::new().try_to_vec().unwrap();

--- a/e2e/dummy/src/generated/instructions/instruction5.rs
+++ b/e2e/dummy/src/generated/instructions/instruction5.rs
@@ -163,8 +163,8 @@ impl<'a, 'b> Instruction5Cpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = Instruction5InstructionData::new().try_to_vec().unwrap();

--- a/e2e/dummy/src/generated/instructions/instruction6.rs
+++ b/e2e/dummy/src/generated/instructions/instruction6.rs
@@ -156,8 +156,8 @@ impl<'a, 'b> Instruction6Cpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = Instruction6InstructionData::new().try_to_vec().unwrap();

--- a/e2e/dummy/src/generated/instructions/instruction7.rs
+++ b/e2e/dummy/src/generated/instructions/instruction7.rs
@@ -168,8 +168,8 @@ impl<'a, 'b> Instruction7Cpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = Instruction7InstructionData::new().try_to_vec().unwrap();

--- a/e2e/memo/src/generated/instructions/add_memo.rs
+++ b/e2e/memo/src/generated/instructions/add_memo.rs
@@ -160,8 +160,8 @@ impl<'a, 'b> AddMemoCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AddMemoInstructionData::new().try_to_vec().unwrap();

--- a/e2e/system/src/generated/instructions/advance_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/advance_nonce_account.rs
@@ -217,8 +217,8 @@ impl<'a, 'b> AdvanceNonceAccountCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = AdvanceNonceAccountInstructionData::new()

--- a/e2e/system/src/generated/instructions/allocate.rs
+++ b/e2e/system/src/generated/instructions/allocate.rs
@@ -188,8 +188,8 @@ impl<'a, 'b> AllocateCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AllocateInstructionData::new().try_to_vec().unwrap();

--- a/e2e/system/src/generated/instructions/allocate_with_seed.rs
+++ b/e2e/system/src/generated/instructions/allocate_with_seed.rs
@@ -245,8 +245,8 @@ impl<'a, 'b> AllocateWithSeedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AllocateWithSeedInstructionData::new().try_to_vec().unwrap();

--- a/e2e/system/src/generated/instructions/assign.rs
+++ b/e2e/system/src/generated/instructions/assign.rs
@@ -192,8 +192,8 @@ impl<'a, 'b> AssignCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AssignInstructionData::new().try_to_vec().unwrap();

--- a/e2e/system/src/generated/instructions/assign_with_seed.rs
+++ b/e2e/system/src/generated/instructions/assign_with_seed.rs
@@ -234,8 +234,8 @@ impl<'a, 'b> AssignWithSeedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AssignWithSeedInstructionData::new().try_to_vec().unwrap();

--- a/e2e/system/src/generated/instructions/authorize_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/authorize_nonce_account.rs
@@ -223,8 +223,8 @@ impl<'a, 'b> AuthorizeNonceAccountCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = AuthorizeNonceAccountInstructionData::new()

--- a/e2e/system/src/generated/instructions/create_account.rs
+++ b/e2e/system/src/generated/instructions/create_account.rs
@@ -228,8 +228,8 @@ impl<'a, 'b> CreateAccountCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = CreateAccountInstructionData::new().try_to_vec().unwrap();

--- a/e2e/system/src/generated/instructions/create_account_with_seed.rs
+++ b/e2e/system/src/generated/instructions/create_account_with_seed.rs
@@ -272,8 +272,8 @@ impl<'a, 'b> CreateAccountWithSeedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = CreateAccountWithSeedInstructionData::new()

--- a/e2e/system/src/generated/instructions/initialize_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/initialize_nonce_account.rs
@@ -255,8 +255,8 @@ impl<'a, 'b> InitializeNonceAccountCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = InitializeNonceAccountInstructionData::new()

--- a/e2e/system/src/generated/instructions/transfer_sol.rs
+++ b/e2e/system/src/generated/instructions/transfer_sol.rs
@@ -208,8 +208,8 @@ impl<'a, 'b> TransferSolCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = TransferSolInstructionData::new().try_to_vec().unwrap();

--- a/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
+++ b/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
@@ -256,8 +256,8 @@ impl<'a, 'b> TransferSolWithSeedCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = TransferSolWithSeedInstructionData::new()

--- a/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
@@ -165,8 +165,8 @@ impl<'a, 'b> UpgradeNonceAccountCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let data = UpgradeNonceAccountInstructionData::new()

--- a/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
@@ -302,8 +302,8 @@ impl<'a, 'b> WithdrawNonceAccountCpi<'a, 'b> {
         remaining_accounts.iter().for_each(|remaining_account| {
             accounts.push(solana_instruction::AccountMeta {
                 pubkey: *remaining_account.0.key,
-                is_signer: remaining_account.1,
-                is_writable: remaining_account.2,
+                is_writable: remaining_account.1,
+                is_signer: remaining_account.2,
             })
         });
         let mut data = WithdrawNonceAccountInstructionData::new()

--- a/public/templates/instructionsCpiPage.njk
+++ b/public/templates/instructionsCpiPage.njk
@@ -147,8 +147,8 @@ impl<'a, 'b> {{ instruction.name | pascalCase }}Cpi<'a, 'b> {
     remaining_accounts.iter().for_each(|remaining_account| {
       accounts.push(solana_instruction::AccountMeta {
           pubkey: *remaining_account.0.key,
-          is_signer: remaining_account.1,
-          is_writable: remaining_account.2,
+          is_writable: remaining_account.1,
+          is_signer: remaining_account.2,
       })
     });
     let {{ 'mut ' if hasArgs }}data = {{ instruction.name | pascalCase }}InstructionData::new().try_to_vec().unwrap();


### PR DESCRIPTION
# Summary
The remaining account tuple is stored as `(account, is_writable, is_signer)` in [builder](https://github.com/codama-idl/renderers-rust/blob/main/public/templates/instructionsCpiPageBuilder.njk#L78-L81) as well as in [definition](https://github.com/codama-idl/renderers-rust/blob/main/public/templates/instructionsCpiPageBuilder.njk#L143-L144). However, when invoke with remaining accounts, the order is swapped, see [here](https://github.com/codama-idl/renderers-rust/blob/main/public/templates/instructionsCpiPage.njk#L147-L153).

This PR fixes the order when invoke, and related e2e tests.