### PR TITLE
Fix/num traits peer dependency

### DIFF
--- a/.changeset/gold-parts-stare.md
+++ b/.changeset/gold-parts-stare.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+fix: include num-traits in Cargo.toml when num-derive is used

--- a/src/utils/cargoToml.ts
+++ b/src/utils/cargoToml.ts
@@ -39,6 +39,19 @@ type CargoDependencyObject = {
     workspace?: boolean;
 };
 
+/**
+ * Proc-macro crates whose generated code depends on runtime crates that
+ * won't appear in the rendered source text. When a key crate is detected
+ * as used, all its peer crates are implicitly included.
+ *
+ * Example: `#[derive(num_derive::FromPrimitive)]` expands to code that
+ * references `num_traits::FromPrimitive`, so `num-traits` must be present
+ * in Cargo.toml whenever `num-derive` is used.
+ */
+export const PEER_DEPENDENCIES: Record<string, string[]> = {
+    'num-derive': ['num-traits'],
+};
+
 export const DEFAULT_DEPENDENCY_VERSIONS: CargoDependencies = {
     'anchor-lang': { optional: true, version: '~0.31' },
     borsh: '^0.10',
@@ -231,6 +244,12 @@ export function getUsedDependencyVersions(
         [{} as CargoDependencies, new Set<string>()],
     );
 
+    // Expand peer dependencies: proc-macro crates like `num-derive` generate
+    // code that depends on runtime crates like `num-traits` at compile time.
+    // Since these runtime crates never appear in the rendered source text,
+    // they won't be detected by import scanning — we must add them explicitly.
+    expandPeerDependencies(usedDependencyVersion, dependencyVersionsWithDefaults, missingDependencies);
+
     if (missingDependencies.size > 0) {
         throw new CodamaError(CODAMA_ERROR__RENDERERS__MISSING_DEPENDENCY_VERSIONS, {
             dependencies: [...missingDependencies],
@@ -239,6 +258,42 @@ export function getUsedDependencyVersions(
     }
 
     return usedDependencyVersion;
+}
+
+/**
+ * For each detected dependency, check if it has peer dependencies that must
+ * also be present (e.g. `num-derive` requires `num-traits` at runtime).
+ * If a peer is not already in the used set, look it up in the version map
+ * and add it. If it can't be resolved, add it to missingDependencies so
+ * the caller can surface the error.
+ */
+function expandPeerDependencies(
+    usedDependencyVersion: CargoDependencies,
+    dependencyVersionsWithDefaults: CargoDependencies,
+    missingDependencies: Set<string>,
+): void {
+    // Snapshot keys to avoid iterating over newly added entries.
+    const currentKeys = Object.keys(usedDependencyVersion);
+
+    for (const depKey of currentKeys) {
+        const peers = PEER_DEPENDENCIES[depKey];
+        if (!peers) continue;
+
+        for (const peerCrateName of peers) {
+            // Skip if already resolved.
+            const peerImportName = getCargoDependencyImportName(peerCrateName);
+            const alreadyPresent = findCargoDependencyByImportName(usedDependencyVersion, peerImportName);
+            if (alreadyPresent) continue;
+
+            // Look up the peer in the version map.
+            const peerDep = findCargoDependencyByImportName(dependencyVersionsWithDefaults, peerImportName);
+            if (peerDep) {
+                usedDependencyVersion[peerDep[0]] = peerDep[1];
+            } else {
+                missingDependencies.add(peerCrateName);
+            }
+        }
+    }
 }
 
 function getUsedImportNames(renderMap: RenderMap<Fragment>, dependencyMap: Record<string, string>): Set<string> {

--- a/test/utils/cargoToml.test.ts
+++ b/test/utils/cargoToml.test.ts
@@ -8,6 +8,7 @@ import {
     DEFAULT_DEPENDENCY_VERSIONS,
     Fragment,
     getUsedDependencyVersions,
+    PEER_DEPENDENCIES,
     shouldUpdateRange,
     updateExistingCargoToml,
 } from '../../src/utils';
@@ -280,5 +281,76 @@ describe('shouldUpdateRange', () => {
     test('it handles equal versions like locked versions', () => {
         expect(shouldUpdateRange('module', '=1.0.0', '=1.1.0')).toBe(true);
         expect(shouldUpdateRange('module', '=1.1.0', '=1.0.0')).toBe(false);
+    });
+});
+
+describe('peer dependencies', () => {
+    test('it includes num-traits when num-derive is used via derive attribute', () => {
+        // Simulates generated code containing `#[derive(num_derive::FromPrimitive)]`.
+        // The content scanner detects `num_derive` but `num_traits` never appears
+        // in the rendered source — it's only referenced by the proc-macro expansion.
+        const renderMap = createRenderMap({
+            'my_enum.rs': fragment(
+                '#[derive(num_derive::FromPrimitive)]\npub enum MyEnum { A, B, C }',
+            ),
+        });
+
+        const result = getUsedDependencyVersions(renderMap, {}, {});
+        expect(result).toHaveProperty('num-derive', DEFAULT_DEPENDENCY_VERSIONS['num-derive']);
+        expect(result).toHaveProperty('num-traits', DEFAULT_DEPENDENCY_VERSIONS['num-traits']);
+    });
+
+    test('it includes num-traits when num-derive is used via ImportMap', () => {
+        // Simulates the trait renderer adding `num_derive::FromPrimitive` to
+        // the ImportMap (when useFullyQualifiedName is false).
+        const renderMap = createRenderMap({
+            'my_enum.rs': use('num_derive::FromPrimitive'),
+        });
+
+        const result = getUsedDependencyVersions(renderMap, {}, {});
+        expect(result).toHaveProperty('num-derive', DEFAULT_DEPENDENCY_VERSIONS['num-derive']);
+        expect(result).toHaveProperty('num-traits', DEFAULT_DEPENDENCY_VERSIONS['num-traits']);
+    });
+
+    test('it does not duplicate num-traits if already explicitly used', () => {
+        const renderMap = createRenderMap({
+            'my_enum.rs': {
+                content: '#[derive(num_derive::FromPrimitive)]\npub enum MyEnum { A }',
+                imports: new ImportMap().add('num_traits::FromPrimitive'),
+            },
+        });
+
+        const result = getUsedDependencyVersions(renderMap, {}, {});
+        expect(result).toHaveProperty('num-derive');
+        expect(result).toHaveProperty('num-traits');
+        // Ensure no duplicate keys — Object.keys is sufficient since keys are unique.
+        const numTraitsEntries = Object.keys(result).filter(k => k === 'num-traits');
+        expect(numTraitsEntries).toHaveLength(1);
+    });
+
+    test('it respects user-provided dependencyVersions for peer dependencies', () => {
+        const renderMap = createRenderMap({
+            'my_enum.rs': fragment('#[derive(num_derive::FromPrimitive)]\npub enum MyEnum { A }'),
+        });
+        const customVersions = { 'num-traits': '^0.3' };
+
+        const result = getUsedDependencyVersions(renderMap, {}, customVersions);
+        expect(result['num-traits']).toBe('^0.3');
+    });
+
+    test('it does not include peer dependencies when the parent is not used', () => {
+        const renderMap = createRenderMap({
+            'my_struct.rs': use('borsh::BorshSerialize'),
+        });
+
+        const result = getUsedDependencyVersions(renderMap, {}, {});
+        expect(result).toHaveProperty('borsh');
+        expect(result).not.toHaveProperty('num-derive');
+        expect(result).not.toHaveProperty('num-traits');
+    });
+
+    test('PEER_DEPENDENCIES maps num-derive to num-traits', () => {
+        expect(PEER_DEPENDENCIES).toHaveProperty('num-derive');
+        expect(PEER_DEPENDENCIES['num-derive']).toContain('num-traits');
     });
 });


### PR DESCRIPTION
# fix: include `num-traits` in Cargo.toml when `num-derive` is used

## Problem

When `syncCargoToml: true`, the generated `Cargo.toml` includes `num-derive` but not `num-traits`, causing `error[E0463]: can't find crate for num_traits`. Although `num-traits` is listed in `DEFAULT_DEPENDENCY_VERSIONS`, that map is only a **version lookup table** — a dependency only gets added to `Cargo.toml` if it's first detected as "used" by scanning rendered source for crate references. The scanner correctly finds `num_derive` from `#[derive(num_derive::FromPrimitive)]` in generated code, but `num_traits` never appears in source — it's only referenced inside the proc-macro expansion that `rustc` produces at compile time. Since the scanner never sees `num_traits`, it's never looked up in `DEFAULT_DEPENDENCY_VERSIONS` and never written to `Cargo.toml`.

## Fix

Adds a `PEER_DEPENDENCIES` map that declares runtime crates required by proc-macro crates (`num-derive` → `num-traits`). After the initial import scan in `getUsedDependencyVersions()`, a new `expandPeerDependencies()` step adds any missing peers, respecting user-provided version overrides and routing unresolvable peers through the existing error path.