### PR TITLE
no-std clients

### DIFF
--- a/.changeset/violet-brooms-brake.md
+++ b/.changeset/violet-brooms-brake.md
@@ -1,0 +1,16 @@
+---
+'@codama/renderers-rust': major
+---
+
+Make generated Rust clients `no_std`-compatible by default.
+
+Generated Rust output now emits `extern crate alloc`, replaces `std` collection and string usage with `alloc`-backed equivalents, and fails rendering if any `std::` references remain in generated files.
+
+This changes part of the generated API surface:
+- map and set types now use `BTreeMap` and `BTreeSet`
+- generated scalar enums now also derive `Ord` by default
+- Borsh serialization and deserialization helpers now return `borsh::io::Error` instead of `std::io::Error`
+
+When syncing Cargo dependencies, the renderer now disables default features for crates that would otherwise pull in `std` and upgrades `thiserror` to v2 with `default-features = false`.
+
+This is a breaking change because upgrading changes generated Rust types, error types, and synced Cargo dependency declarations for existing clients.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,7 @@ dependencies = [
  "solana-cpi 3.1.0",
  "solana-instruction 3.2.0",
  "solana-program-error 3.0.0",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -750,7 +750,7 @@ dependencies = [
  "solana-instruction 3.2.0",
  "solana-program-error 3.0.0",
  "spl-collections",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -768,7 +768,7 @@ dependencies = [
  "solana-cpi 3.1.0",
  "solana-instruction 3.2.0",
  "solana-program-error 3.0.0",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,16 @@ resolver = "2"
 
 [workspace.dependencies]
 anchor-lang = "~0.31"
-borsh = "^1.0"
+borsh = { version = "^1.0", default-features = false, features = ["derive"] }
 num-derive = "^0.4"
-num-traits = "^0.2"
+num-traits = { version = "^0.2", default-features = false }
 solana-account = "~3.0"
 solana-account-info = "~3.1"
 solana-address = "~2.2"
 solana-client = "~3.0"
 solana-cpi = "~3.1"
 solana-decode-error = "~2.3"
-solana-instruction = "~3.2"
+solana-instruction = { version = "~3.2", default-features = false }
 solana-program-error = "~3.0"
 spl-collections = "0.1.1"
-thiserror = "^1.0"
+thiserror = { version = "^2.0", default-features = false }

--- a/e2e/anchor/src/generated/accounts/guard_v1.rs
+++ b/e2e/anchor/src/generated/accounts/guard_v1.rs
@@ -8,6 +8,7 @@
 use crate::generated::types::CpiRule;
 use crate::generated::types::MetadataAdditionalFieldRule;
 use crate::generated::types::TransferAmountRule;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -31,14 +32,14 @@ pub const GUARD_V1_DISCRIMINATOR: [u8; 8] = [185, 149, 156, 78, 245, 108, 172, 6
 
 impl GuardV1 {
     #[inline(always)]
-    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, borsh::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)
     }
 }
 
 impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for GuardV1 {
-    type Error = std::io::Error;
+    type Error = borsh::io::Error;
 
     fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
@@ -50,7 +51,7 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for GuardV1 {
 pub fn fetch_guard_v1(
     rpc: &solana_client::rpc_client::RpcClient,
     address: &solana_address::Address,
-) -> Result<crate::shared::DecodedAccount<GuardV1>, std::io::Error> {
+) -> Result<crate::shared::DecodedAccount<GuardV1>, borsh::io::Error> {
     let accounts = fetch_all_guard_v1(rpc, &[*address])?;
     Ok(accounts[0].clone())
 }
@@ -59,16 +60,19 @@ pub fn fetch_guard_v1(
 pub fn fetch_all_guard_v1(
     rpc: &solana_client::rpc_client::RpcClient,
     addresses: &[solana_address::Address],
-) -> Result<Vec<crate::shared::DecodedAccount<GuardV1>>, std::io::Error> {
+) -> Result<alloc::vec::Vec<crate::shared::DecodedAccount<GuardV1>>, borsh::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-    let mut decoded_accounts: Vec<crate::shared::DecodedAccount<GuardV1>> = Vec::new();
+        .map_err(|e| borsh::io::Error::other(alloc::format!("{e}")))?;
+    let mut decoded_accounts: alloc::vec::Vec<crate::shared::DecodedAccount<GuardV1>> =
+        alloc::vec::Vec::new();
     for i in 0..addresses.len() {
         let address = addresses[i];
-        let account = accounts[i].as_ref().ok_or(std::io::Error::other(format!(
-            "Account not found: {address}"
-        )))?;
+        let account = accounts[i]
+            .as_ref()
+            .ok_or(borsh::io::Error::other(alloc::format!(
+                "Account not found: {address}"
+            )))?;
         let data = GuardV1::from_bytes(&account.data)?;
         decoded_accounts.push(crate::shared::DecodedAccount {
             address,
@@ -83,7 +87,7 @@ pub fn fetch_all_guard_v1(
 pub fn fetch_maybe_guard_v1(
     rpc: &solana_client::rpc_client::RpcClient,
     address: &solana_address::Address,
-) -> Result<crate::shared::MaybeAccount<GuardV1>, std::io::Error> {
+) -> Result<crate::shared::MaybeAccount<GuardV1>, borsh::io::Error> {
     let accounts = fetch_all_maybe_guard_v1(rpc, &[*address])?;
     Ok(accounts[0].clone())
 }
@@ -92,11 +96,12 @@ pub fn fetch_maybe_guard_v1(
 pub fn fetch_all_maybe_guard_v1(
     rpc: &solana_client::rpc_client::RpcClient,
     addresses: &[solana_address::Address],
-) -> Result<Vec<crate::shared::MaybeAccount<GuardV1>>, std::io::Error> {
+) -> Result<alloc::vec::Vec<crate::shared::MaybeAccount<GuardV1>>, borsh::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-    let mut decoded_accounts: Vec<crate::shared::MaybeAccount<GuardV1>> = Vec::new();
+        .map_err(|e| borsh::io::Error::other(alloc::format!("{e}")))?;
+    let mut decoded_accounts: alloc::vec::Vec<crate::shared::MaybeAccount<GuardV1>> =
+        alloc::vec::Vec::new();
     for i in 0..addresses.len() {
         let address = addresses[i];
         if let Some(account) = accounts[i].as_ref() {

--- a/e2e/anchor/src/generated/instructions/create_guard.rs
+++ b/e2e/anchor/src/generated/instructions/create_guard.rs
@@ -8,6 +8,9 @@
 use crate::generated::types::CpiRule;
 use crate::generated::types::MetadataAdditionalFieldRule;
 use crate::generated::types::TransferAmountRule;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -93,7 +96,7 @@ impl CreateGuardInstructionData {
         }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -115,7 +118,7 @@ pub struct CreateGuardInstructionArgs {
 }
 
 impl CreateGuardInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/anchor/src/generated/instructions/execute.rs
+++ b/e2e/anchor/src/generated/instructions/execute.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -91,7 +93,7 @@ impl ExecuteInstructionData {
         }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -108,7 +110,7 @@ pub struct ExecuteInstructionArgs {
 }
 
 impl ExecuteInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/anchor/src/generated/instructions/initialize.rs
+++ b/e2e/anchor/src/generated/instructions/initialize.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -79,7 +81,7 @@ impl InitializeInstructionData {
         }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/anchor/src/generated/instructions/update_guard.rs
+++ b/e2e/anchor/src/generated/instructions/update_guard.rs
@@ -8,6 +8,8 @@
 use crate::generated::types::CpiRule;
 use crate::generated::types::MetadataAdditionalFieldRule;
 use crate::generated::types::TransferAmountRule;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -86,7 +88,7 @@ impl UpdateGuardInstructionData {
         }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -105,7 +107,7 @@ pub struct UpdateGuardInstructionArgs {
 }
 
 impl UpdateGuardInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/anchor/src/generated/mod.rs
+++ b/e2e/anchor/src/generated/mod.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+extern crate alloc;
+
 pub mod accounts;
 pub mod errors;
 pub mod instructions;

--- a/e2e/anchor/src/generated/types/cpi_rule.rs
+++ b/e2e/anchor/src/generated/types/cpi_rule.rs
@@ -5,6 +5,7 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;

--- a/e2e/anchor/src/generated/types/metadata_additional_field_restriction.rs
+++ b/e2e/anchor/src/generated/types/metadata_additional_field_restriction.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::string::String;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 

--- a/e2e/anchor/src/generated/types/metadata_additional_field_rule.rs
+++ b/e2e/anchor/src/generated/types/metadata_additional_field_rule.rs
@@ -6,6 +6,7 @@
 //!
 
 use crate::generated::types::MetadataAdditionalFieldRestriction;
+use alloc::string::String;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 

--- a/e2e/anchor/src/lib.rs
+++ b/e2e/anchor/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 mod generated;
 
 pub use generated::programs::WEN_TRANSFER_GUARD_ID as ID;

--- a/e2e/dummy/src/generated/instructions/instruction1.rs
+++ b/e2e/dummy/src/generated/instructions/instruction1.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -42,7 +44,7 @@ impl Instruction1InstructionData {
         Self {}
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/dummy/src/generated/instructions/instruction2.rs
+++ b/e2e/dummy/src/generated/instructions/instruction2.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -42,7 +44,7 @@ impl Instruction2InstructionData {
         Self {}
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/dummy/src/generated/instructions/instruction3.rs
+++ b/e2e/dummy/src/generated/instructions/instruction3.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -46,7 +48,7 @@ impl Instruction3InstructionData {
         Self { discriminator: 42 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/dummy/src/generated/instructions/instruction4.rs
+++ b/e2e/dummy/src/generated/instructions/instruction4.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -48,7 +50,7 @@ impl Instruction4InstructionData {
         Self {}
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -65,7 +67,7 @@ pub struct Instruction4InstructionArgs {
 }
 
 impl Instruction4InstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/dummy/src/generated/instructions/instruction5.rs
+++ b/e2e/dummy/src/generated/instructions/instruction5.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -48,7 +50,7 @@ impl Instruction5InstructionData {
         Self {}
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -65,7 +67,7 @@ pub struct Instruction5InstructionArgs {
 }
 
 impl Instruction5InstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/dummy/src/generated/instructions/instruction6.rs
+++ b/e2e/dummy/src/generated/instructions/instruction6.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -45,7 +47,7 @@ impl Instruction6InstructionData {
         Self {}
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/dummy/src/generated/instructions/instruction7.rs
+++ b/e2e/dummy/src/generated/instructions/instruction7.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -52,7 +54,7 @@ impl Instruction7InstructionData {
         Self {}
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/dummy/src/generated/mod.rs
+++ b/e2e/dummy/src/generated/mod.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+extern crate alloc;
+
 pub mod errors;
 pub mod instructions;
 pub mod programs;

--- a/e2e/dummy/src/lib.rs
+++ b/e2e/dummy/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 mod generated;
 
 pub use generated::programs::DUMMY_ID as ID;

--- a/e2e/memo/src/generated/instructions/add_memo.rs
+++ b/e2e/memo/src/generated/instructions/add_memo.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use spl_collections::TrailingStr;
@@ -46,7 +48,7 @@ impl AddMemoInstructionData {
         Self {}
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -63,7 +65,7 @@ pub struct AddMemoInstructionArgs {
 }
 
 impl AddMemoInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/memo/src/generated/mod.rs
+++ b/e2e/memo/src/generated/mod.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+extern crate alloc;
+
 pub mod errors;
 pub mod instructions;
 pub mod programs;

--- a/e2e/memo/src/lib.rs
+++ b/e2e/memo/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 mod generated;
 
 pub use generated::programs::MEMO_ID as ID;

--- a/e2e/system/src/generated/accounts/nonce.rs
+++ b/e2e/system/src/generated/accounts/nonce.rs
@@ -24,14 +24,14 @@ impl Nonce {
     pub const LEN: usize = 80;
 
     #[inline(always)]
-    pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+    pub fn from_bytes(data: &[u8]) -> Result<Self, borsh::io::Error> {
         let mut data = data;
         Self::deserialize(&mut data)
     }
 }
 
 impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for Nonce {
-    type Error = std::io::Error;
+    type Error = borsh::io::Error;
 
     fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
         let mut data: &[u8] = &(*account_info.data).borrow();
@@ -43,7 +43,7 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for Nonce {
 pub fn fetch_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
     address: &solana_address::Address,
-) -> Result<crate::shared::DecodedAccount<Nonce>, std::io::Error> {
+) -> Result<crate::shared::DecodedAccount<Nonce>, borsh::io::Error> {
     let accounts = fetch_all_nonce(rpc, &[*address])?;
     Ok(accounts[0].clone())
 }
@@ -52,16 +52,19 @@ pub fn fetch_nonce(
 pub fn fetch_all_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
     addresses: &[solana_address::Address],
-) -> Result<Vec<crate::shared::DecodedAccount<Nonce>>, std::io::Error> {
+) -> Result<alloc::vec::Vec<crate::shared::DecodedAccount<Nonce>>, borsh::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-    let mut decoded_accounts: Vec<crate::shared::DecodedAccount<Nonce>> = Vec::new();
+        .map_err(|e| borsh::io::Error::other(alloc::format!("{e}")))?;
+    let mut decoded_accounts: alloc::vec::Vec<crate::shared::DecodedAccount<Nonce>> =
+        alloc::vec::Vec::new();
     for i in 0..addresses.len() {
         let address = addresses[i];
-        let account = accounts[i].as_ref().ok_or(std::io::Error::other(format!(
-            "Account not found: {address}"
-        )))?;
+        let account = accounts[i]
+            .as_ref()
+            .ok_or(borsh::io::Error::other(alloc::format!(
+                "Account not found: {address}"
+            )))?;
         let data = Nonce::from_bytes(&account.data)?;
         decoded_accounts.push(crate::shared::DecodedAccount {
             address,
@@ -76,7 +79,7 @@ pub fn fetch_all_nonce(
 pub fn fetch_maybe_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
     address: &solana_address::Address,
-) -> Result<crate::shared::MaybeAccount<Nonce>, std::io::Error> {
+) -> Result<crate::shared::MaybeAccount<Nonce>, borsh::io::Error> {
     let accounts = fetch_all_maybe_nonce(rpc, &[*address])?;
     Ok(accounts[0].clone())
 }
@@ -85,11 +88,12 @@ pub fn fetch_maybe_nonce(
 pub fn fetch_all_maybe_nonce(
     rpc: &solana_client::rpc_client::RpcClient,
     addresses: &[solana_address::Address],
-) -> Result<Vec<crate::shared::MaybeAccount<Nonce>>, std::io::Error> {
+) -> Result<alloc::vec::Vec<crate::shared::MaybeAccount<Nonce>>, borsh::io::Error> {
     let accounts = rpc
         .get_multiple_accounts(addresses)
-        .map_err(|e| std::io::Error::other(e.to_string()))?;
-    let mut decoded_accounts: Vec<crate::shared::MaybeAccount<Nonce>> = Vec::new();
+        .map_err(|e| borsh::io::Error::other(alloc::format!("{e}")))?;
+    let mut decoded_accounts: alloc::vec::Vec<crate::shared::MaybeAccount<Nonce>> =
+        alloc::vec::Vec::new();
     for i in 0..addresses.len() {
         let address = addresses[i];
         if let Some(account) = accounts[i].as_ref() {

--- a/e2e/system/src/generated/instructions/advance_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/advance_nonce_account.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -66,7 +68,7 @@ impl AdvanceNonceAccountInstructionData {
         Self { discriminator: 4 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/allocate.rs
+++ b/e2e/system/src/generated/instructions/allocate.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -52,7 +54,7 @@ impl AllocateInstructionData {
         Self { discriminator: 8 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -69,7 +71,7 @@ pub struct AllocateInstructionArgs {
 }
 
 impl AllocateInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/allocate_with_seed.rs
+++ b/e2e/system/src/generated/instructions/allocate_with_seed.rs
@@ -5,6 +5,9 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -65,7 +68,7 @@ impl AllocateWithSeedInstructionData {
         Self { discriminator: 9 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -85,7 +88,7 @@ pub struct AllocateWithSeedInstructionArgs {
 }
 
 impl AllocateWithSeedInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/assign.rs
+++ b/e2e/system/src/generated/instructions/assign.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -53,7 +55,7 @@ impl AssignInstructionData {
         Self { discriminator: 1 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -70,7 +72,7 @@ pub struct AssignInstructionArgs {
 }
 
 impl AssignInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/assign_with_seed.rs
+++ b/e2e/system/src/generated/instructions/assign_with_seed.rs
@@ -5,6 +5,9 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -62,7 +65,7 @@ impl AssignWithSeedInstructionData {
         Self { discriminator: 10 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -81,7 +84,7 @@ pub struct AssignWithSeedInstructionArgs {
 }
 
 impl AssignWithSeedInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/authorize_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/authorize_nonce_account.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -67,7 +69,7 @@ impl AuthorizeNonceAccountInstructionData {
         Self { discriminator: 7 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -84,7 +86,7 @@ pub struct AuthorizeNonceAccountInstructionArgs {
 }
 
 impl AuthorizeNonceAccountInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/create_account.rs
+++ b/e2e/system/src/generated/instructions/create_account.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -59,7 +61,7 @@ impl CreateAccountInstructionData {
         Self { discriminator: 0 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -78,7 +80,7 @@ pub struct CreateAccountInstructionArgs {
 }
 
 impl CreateAccountInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/create_account_with_seed.rs
+++ b/e2e/system/src/generated/instructions/create_account_with_seed.rs
@@ -5,6 +5,9 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -70,7 +73,7 @@ impl CreateAccountWithSeedInstructionData {
         Self { discriminator: 3 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -91,7 +94,7 @@ pub struct CreateAccountWithSeedInstructionArgs {
 }
 
 impl CreateAccountWithSeedInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/initialize_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/initialize_nonce_account.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -73,7 +75,7 @@ impl InitializeNonceAccountInstructionData {
         Self { discriminator: 6 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -90,7 +92,7 @@ pub struct InitializeNonceAccountInstructionArgs {
 }
 
 impl InitializeNonceAccountInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/transfer_sol.rs
+++ b/e2e/system/src/generated/instructions/transfer_sol.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -58,7 +60,7 @@ impl TransferSolInstructionData {
         Self { discriminator: 2 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -75,7 +77,7 @@ pub struct TransferSolInstructionArgs {
 }
 
 impl TransferSolInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
+++ b/e2e/system/src/generated/instructions/transfer_sol_with_seed.rs
@@ -5,6 +5,9 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 use solana_address::Address;
@@ -70,7 +73,7 @@ impl TransferSolWithSeedInstructionData {
         Self { discriminator: 11 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -89,7 +92,7 @@ pub struct TransferSolWithSeedInstructionArgs {
 }
 
 impl TransferSolWithSeedInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/upgrade_nonce_account.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -54,7 +56,7 @@ impl UpgradeNonceAccountInstructionData {
         Self { discriminator: 12 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
+++ b/e2e/system/src/generated/instructions/withdraw_nonce_account.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use borsh::BorshDeserialize;
 use borsh::BorshSerialize;
 
@@ -84,7 +86,7 @@ impl WithdrawNonceAccountInstructionData {
         Self { discriminator: 5 }
     }
 
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }
@@ -101,7 +103,7 @@ pub struct WithdrawNonceAccountInstructionArgs {
 }
 
 impl WithdrawNonceAccountInstructionArgs {
-    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+    pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
         borsh::to_vec(self)
     }
 }

--- a/e2e/system/src/generated/mod.rs
+++ b/e2e/system/src/generated/mod.rs
@@ -5,6 +5,8 @@
 //! <https://github.com/codama-idl/codama>
 //!
 
+extern crate alloc;
+
 pub mod accounts;
 pub mod errors;
 pub mod instructions;

--- a/e2e/system/src/generated/types/nonce_state.rs
+++ b/e2e/system/src/generated/types/nonce_state.rs
@@ -18,6 +18,7 @@ use num_derive::FromPrimitive;
     PartialEq,
     Copy,
     PartialOrd,
+    Ord,
     Hash,
     FromPrimitive,
 )]

--- a/e2e/system/src/generated/types/nonce_version.rs
+++ b/e2e/system/src/generated/types/nonce_version.rs
@@ -18,6 +18,7 @@ use num_derive::FromPrimitive;
     PartialEq,
     Copy,
     PartialOrd,
+    Ord,
     Hash,
     FromPrimitive,
 )]

--- a/e2e/system/src/lib.rs
+++ b/e2e/system/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 mod generated;
 
 pub use generated::programs::SYSTEM_ID as ID;

--- a/public/templates/accountsPage.njk
+++ b/public/templates/accountsPage.njk
@@ -73,7 +73,7 @@ impl {{ account.name | pascalCase }} {
             {% elif seed.kind == 'variablePdaSeedNode' and seed.resolvedType.kind == 'bytesTypeNode' %}
               &{{ seed.name | snakeCase }},
             {% else %}
-              {{ seed.name | snakeCase }}.to_string().as_ref(),
+              alloc::string::ToString::to_string(&{{ seed.name | snakeCase }}).as_ref(),
             {% endif %}
           {% endfor %}
           &[bump],
@@ -105,7 +105,7 @@ impl {{ account.name | pascalCase }} {
             {% elif seed.kind == 'variablePdaSeedNode' and seed.resolvedType.kind == 'bytesTypeNode' %}
               &{{ seed.name | snakeCase }},
             {% else %}
-              {{ seed.name | snakeCase }}.to_string().as_ref(),
+              alloc::string::ToString::to_string(&{{ seed.name | snakeCase }}).as_ref(),
             {% endif %}
           {% endfor %}
         ],
@@ -115,14 +115,14 @@ impl {{ account.name | pascalCase }} {
   {% endif %}
 
   #[inline(always)]
-  pub fn from_bytes(data: &[u8]) -> Result<Self, std::io::Error> {
+  pub fn from_bytes(data: &[u8]) -> Result<Self, borsh::io::Error> {
     let mut data = data;
     Self::deserialize(&mut data)
   }
 }
 
 impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for {{ account.name | pascalCase }} {
-  type Error = std::io::Error;
+  type Error = borsh::io::Error;
 
   fn try_from(account_info: &solana_account_info::AccountInfo<'a>) -> Result<Self, Self::Error> {
       let mut data: &[u8] = &(*account_info.data).borrow();
@@ -134,7 +134,7 @@ impl<'a> TryFrom<&solana_account_info::AccountInfo<'a>> for {{ account.name | pa
 pub fn fetch_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
   address: &solana_address::Address,
-) -> Result<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>, std::io::Error> {
+) -> Result<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>, borsh::io::Error> {
   let accounts = fetch_all_{{ account.name | snakeCase }}(rpc, &[*address])?;
   Ok(accounts[0].clone())
 }
@@ -143,14 +143,14 @@ pub fn fetch_{{ account.name | snakeCase }}(
 pub fn fetch_all_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
   addresses: &[solana_address::Address],
-) -> Result<Vec<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>>, std::io::Error> {
+) -> Result<alloc::vec::Vec<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>>, borsh::io::Error> {
     let accounts = rpc.get_multiple_accounts(addresses)
-      .map_err(|e| std::io::Error::other(e.to_string()))?;
-    let mut decoded_accounts: Vec<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>> = Vec::new();
+      .map_err(|e| borsh::io::Error::other(alloc::format!("{e}")))?;
+    let mut decoded_accounts: alloc::vec::Vec<crate::shared::DecodedAccount<{{ account.name | pascalCase }}>> = alloc::vec::Vec::new();
     for i in 0..addresses.len() {
       let address = addresses[i];
       let account = accounts[i].as_ref()
-        .ok_or(std::io::Error::other(format!("Account not found: {address}")))?;
+        .ok_or(borsh::io::Error::other(alloc::format!("Account not found: {address}")))?;
       let data = {{ account.name | pascalCase }}::from_bytes(&account.data)?;
       decoded_accounts.push(crate::shared::DecodedAccount { address, account: account.clone(), data });
     }
@@ -161,7 +161,7 @@ pub fn fetch_all_{{ account.name | snakeCase }}(
 pub fn fetch_maybe_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
   address: &solana_address::Address,
-) -> Result<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>, std::io::Error> {
+) -> Result<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>, borsh::io::Error> {
     let accounts = fetch_all_maybe_{{ account.name | snakeCase }}(rpc, &[*address])?;
     Ok(accounts[0].clone())
 }
@@ -170,10 +170,10 @@ pub fn fetch_maybe_{{ account.name | snakeCase }}(
 pub fn fetch_all_maybe_{{ account.name | snakeCase }}(
   rpc: &solana_client::rpc_client::RpcClient,
   addresses: &[solana_address::Address],
-) -> Result<Vec<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>>, std::io::Error> {
+) -> Result<alloc::vec::Vec<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>>, borsh::io::Error> {
     let accounts = rpc.get_multiple_accounts(addresses)
-      .map_err(|e| std::io::Error::other(e.to_string()))?;
-    let mut decoded_accounts: Vec<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>> = Vec::new();
+      .map_err(|e| borsh::io::Error::other(alloc::format!("{e}")))?;
+    let mut decoded_accounts: alloc::vec::Vec<crate::shared::MaybeAccount<{{ account.name | pascalCase }}>> = alloc::vec::Vec::new();
     for i in 0..addresses.len() {
       let address = addresses[i];
       if let Some(account) = accounts[i].as_ref() {

--- a/public/templates/instructionsPage.njk
+++ b/public/templates/instructionsPage.njk
@@ -131,7 +131,7 @@ impl {{ instruction.name | pascalCase }}InstructionData {
   }
 
   {% if dataTraits | hasTrait('BorshSerialize', 'borsh::BorshSerialize') %}
-  pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+  pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
     borsh::to_vec(self)
   }
   {% endif %}
@@ -154,7 +154,7 @@ impl Default for {{ instruction.name | pascalCase }}InstructionData {
 
 {% if dataTraits | hasTrait('BorshSerialize', 'borsh::BorshSerialize') %}
 impl {{ instruction.name | pascalCase }}InstructionArgs {
-  pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error> {
+  pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error> {
     borsh::to_vec(self)
   }
 }

--- a/public/templates/rootMod.njk
+++ b/public/templates/rootMod.njk
@@ -2,6 +2,8 @@
 
 {% block main %}
 
+extern crate alloc;
+
 {% if hasAnythingToExport %}
   {% if accountsToExport.length > 0 %}
     pub mod accounts;

--- a/src/getRenderMapVisitor.ts
+++ b/src/getRenderMapVisitor.ts
@@ -150,7 +150,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
 
                 visitInstruction(node) {
                     // Imports.
-                    const imports = new ImportMap();
+                    const imports = new ImportMap().add(['alloc::boxed::Box', 'alloc::vec::Vec']);
 
                     // canMergeAccountsAndArgs
                     const accountsAndArgsConflicts = getConflictsForInstructionAccountsAndArgs(node);

--- a/src/getTypeManifestVisitor.ts
+++ b/src/getTypeManifestVisitor.ts
@@ -98,6 +98,7 @@ export function getTypeManifestVisitor(options: {
                             case 'u32':
                                 return {
                                     ...childManifest,
+                                    imports: childManifest.imports.add('alloc::vec::Vec'),
                                     type: `Vec<${childManifest.type}>`,
                                 };
                             case 'u8':
@@ -267,10 +268,10 @@ export function getTypeManifestVisitor(options: {
                     const key = visit(mapType.key, self);
                     const value = visit(mapType.value, self);
                     const mergedManifest = mergeManifests([key, value]);
-                    mergedManifest.imports.add('std::collections::HashMap');
+                    mergedManifest.imports.add('alloc::collections::BTreeMap');
                     return {
                         ...mergedManifest,
-                        type: `HashMap<${key.type}, ${value.type}>`,
+                        type: `BTreeMap<${key.type}, ${value.type}>`,
                     };
                 },
 
@@ -324,10 +325,10 @@ export function getTypeManifestVisitor(options: {
 
                 visitSetType(setType, { self }) {
                     const childManifest = visit(setType.item, self);
-                    childManifest.imports.add('std::collections::HashSet');
+                    childManifest.imports.add('alloc::collections::BTreeSet');
                     return {
                         ...childManifest,
-                        type: `HashSet<${childManifest.type}>`,
+                        type: `BTreeSet<${childManifest.type}>`,
                     };
                 },
 
@@ -359,7 +360,7 @@ export function getTypeManifestVisitor(options: {
                         switch (parentSize.format) {
                             case 'u32':
                                 return {
-                                    imports: new ImportMap(),
+                                    imports: new ImportMap().add('alloc::string::String'),
                                     nestedStructs: [],
                                     type: 'String',
                                 };

--- a/src/renderValueNodeVisitor.ts
+++ b/src/renderValueNodeVisitor.ts
@@ -94,10 +94,10 @@ export function renderValueNodeVisitor(
         },
         visitMapValue(node) {
             const map = node.entries.map(entry => visit(entry, this));
-            const imports = new ImportMap().add('std::collection::HashMap');
+            const imports = new ImportMap().add('alloc::collections::BTreeMap');
             return {
                 imports: imports.mergeWith(...map.map(c => c.imports)),
-                render: `HashMap::from([${map.map(c => c.render).join(', ')}])`,
+                render: `BTreeMap::from([${map.map(c => c.render).join(', ')}])`,
             };
         },
         visitNoneValue() {
@@ -120,10 +120,10 @@ export function renderValueNodeVisitor(
         },
         visitSetValue(node) {
             const set = node.items.map(v => visit(v, this));
-            const imports = new ImportMap().add('std::collection::HashSet');
+            const imports = new ImportMap().add('alloc::collections::BTreeSet');
             return {
                 imports: imports.mergeWith(...set.map(c => c.imports)),
-                render: `HashSet::from([${set.map(c => c.render).join(', ')}])`,
+                render: `BTreeSet::from([${set.map(c => c.render).join(', ')}])`,
             };
         },
         visitSomeValue(node) {
@@ -136,7 +136,9 @@ export function renderValueNodeVisitor(
         visitStringValue(node) {
             return {
                 imports: new ImportMap(),
-                render: useStr ? `${JSON.stringify(node.string)}` : `String::from(${JSON.stringify(node.string)})`,
+                render: useStr
+                    ? `${JSON.stringify(node.string)}`
+                    : `alloc::string::String::from(${JSON.stringify(node.string)})`,
             };
         },
         visitStructFieldValue(node) {

--- a/src/renderVisitor.ts
+++ b/src/renderVisitor.ts
@@ -5,6 +5,7 @@ import { spawnSync } from 'child_process';
 
 import { GetRenderMapOptions, getRenderMapVisitor } from './getRenderMapVisitor';
 import { syncCargoToml } from './utils';
+import { assertNoStdCompatible } from './utils/noStd';
 
 export type RenderOptions = GetRenderMapOptions & {
     deleteFolderBeforeRendering?: boolean;
@@ -25,6 +26,7 @@ export function renderVisitor(crateFolder: string, options: RenderOptions = {}) 
 
         // Render the new files.
         const renderMap = visit(root, getRenderMapVisitor(options));
+        assertNoStdCompatible(renderMap);
         writeRenderMap(renderMap, generatedFolder);
 
         // Sync Cargo.toml dependencies and versions, if requested.

--- a/src/utils/cargoToml.ts
+++ b/src/utils/cargoToml.ts
@@ -41,19 +41,19 @@ type CargoDependencyObject = {
 
 export const DEFAULT_DEPENDENCY_VERSIONS: CargoDependencies = {
     'anchor-lang': { optional: true, version: '~0.31' },
-    borsh: '^1.0',
+    borsh: { 'default-features': false, features: ['derive'], version: '^1.0' },
     'num-derive': '^0.4',
-    'num-traits': '^0.2',
+    'num-traits': { 'default-features': false, version: '^0.2' },
     'solana-account': '~3.0',
     'solana-account-info': '~3.1',
     'solana-address': { features: ['borsh', 'copy', 'curve25519', 'decode'], version: '~2.2' },
     'solana-client': { optional: true, version: '^3.0' },
     'solana-cpi': '~3.1',
     'solana-decode-error': '~2.3',
-    'solana-instruction': '~3.2',
+    'solana-instruction': { 'default-features': false, version: '~3.2' },
     'solana-program-error': '~3.0',
     'spl-collections': { features: ['borsh'], version: '^0.1' },
-    thiserror: '^1.0',
+    thiserror: { 'default-features': false, version: '^2.0' },
 };
 
 export function syncCargoToml(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,5 +3,6 @@ export * from './codecs';
 export * from './discriminatorConstant';
 export * from './fragment';
 export * from './linkOverrides';
+export * from './noStd';
 export * from './render';
 export * from './traitOptions';

--- a/src/utils/noStd.ts
+++ b/src/utils/noStd.ts
@@ -1,0 +1,23 @@
+import type { RenderMap } from '@codama/renderers-core';
+
+import type { Fragment } from './fragment';
+
+const STD_REFERENCE_PATTERN = /\bstd::/;
+
+export function assertNoStdCompatible(renderMap: RenderMap<Fragment>): void {
+    const offenders = [...renderMap.entries()].flatMap(([filePath, fragment]) => {
+        return fragment.content
+            .split('\n')
+            .map((line, index) => ({ filePath, line, lineNumber: index + 1 }))
+            .filter(({ line }) => STD_REFERENCE_PATTERN.test(line));
+    });
+
+    if (offenders.length === 0) {
+        return;
+    }
+
+    const details = offenders
+        .map(({ filePath, line, lineNumber }) => `- ${filePath}:${lineNumber}: ${line.trim()}`)
+        .join('\n');
+    throw new Error(`[Rust] Generated output is not no_std-compatible.\n${details}`);
+}

--- a/src/utils/traitOptions.ts
+++ b/src/utils/traitOptions.ts
@@ -42,7 +42,7 @@ export const DEFAULT_TRAIT_OPTIONS: Required<TraitOptions> = {
     dataEnumDefaults: [],
     featureFlags: {},
     overrides: {},
-    scalarEnumDefaults: ['Copy', 'PartialOrd', 'Hash', 'num_derive::FromPrimitive'],
+    scalarEnumDefaults: ['Copy', 'PartialOrd', 'Ord', 'Hash', 'num_derive::FromPrimitive'],
     structDefaults: [],
     useFullyQualifiedName: false,
 };

--- a/test/utils/noStd.test.ts
+++ b/test/utils/noStd.test.ts
@@ -1,0 +1,30 @@
+import { createRenderMap } from '@codama/renderers-core';
+import { describe, expect, test } from 'vitest';
+
+import { ImportMap } from '../../src';
+import { assertNoStdCompatible, Fragment } from '../../src/utils';
+
+function fragment(content: string): Fragment {
+    return {
+        content,
+        imports: new ImportMap(),
+    };
+}
+
+describe('assertNoStdCompatible', () => {
+    test('it accepts alloc-only output', () => {
+        const renderMap = createRenderMap({
+            'lib.rs': fragment('use alloc::vec::Vec;\nextern crate alloc;\n'),
+        });
+
+        expect(() => assertNoStdCompatible(renderMap)).not.toThrow();
+    });
+
+    test('it rejects generated std references', () => {
+        const renderMap = createRenderMap({
+            'lib.rs': fragment('use std::vec::Vec;\n'),
+        });
+
+        expect(() => assertNoStdCompatible(renderMap)).toThrow('[Rust] Generated output is not no_std-compatible.');
+    });
+});

--- a/test/utils/traitOptions.test.ts
+++ b/test/utils/traitOptions.test.ts
@@ -61,7 +61,7 @@ describe('default values', () => {
 
         // Then we expect the following traits to be rendered.
         expect(render).toBe(
-            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Copy, PartialOrd, Hash, FromPrimitive)]\n`,
+            `#[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Copy, PartialOrd, Ord, Hash, FromPrimitive)]\n`,
         );
 
         // And the following imports to be used.
@@ -378,7 +378,7 @@ describe('conditional try_to_vec generation', () => {
 
         // Then we expect the try_to_vec method to be included with borsh::to_vec implementation.
         const instruction = getFromRenderMap(renderMap, 'instructions/transfer.rs').content;
-        expect(instruction).toContain('pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error>');
+        expect(instruction).toContain('pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error>');
         expect(instruction).toContain('borsh::to_vec(self)');
 
         // And the instruction functions should use try_to_vec.
@@ -450,7 +450,7 @@ describe('conditional try_to_vec generation', () => {
 
         // Then we expect try_to_vec to be generated even with fully qualified trait name.
         const instruction = getFromRenderMap(renderMap, 'instructions/transfer.rs').content;
-        expect(instruction).toContain('pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, std::io::Error>');
+        expect(instruction).toContain('pub(crate) fn try_to_vec(&self) -> Result<Vec<u8>, borsh::io::Error>');
         expect(instruction).toContain('borsh::to_vec(self)');
         expect(instruction).toContain('#[derive(borsh::BorshSerialize');
     });


### PR DESCRIPTION
inspired by https://github.com/solana-program/associated-token-account/pull/243#issuecomment-4281565382

At the moment, the generated rust clients use the standard library. This means, for crates or environments that are no-std, it will not compile. This PR updates the rust renderer so generated clients compile in no-std environments by default.

API changes:
- Serialization helpers now return `borsh::io::Error` instead of `std::io::Error`
- Cargo manifests now default key deps to no-std-friendly settings

Think this is an argument for a major version bump.