### PR TITLE
Encode numeric PDA seeds as little-endian bytes

### DIFF
--- a/.changeset/numeric-pda-seed-le-bytes.md
+++ b/.changeset/numeric-pda-seed-le-bytes.md
@@ -1,0 +1,5 @@
+---
+'@codama/renderers-rust': patch
+---
+
+Encode numeric PDA seeds as little-endian bytes in `find_pda`/`create_pda`

--- a/public/templates/accountsPage.njk
+++ b/public/templates/accountsPage.njk
@@ -72,6 +72,8 @@ impl {{ account.name | pascalCase }} {
               {{ seed.name | snakeCase }}.as_ref(),
             {% elif seed.kind == 'variablePdaSeedNode' and seed.resolvedType.kind == 'bytesTypeNode' %}
               &{{ seed.name | snakeCase }},
+            {% elif seed.kind == 'variablePdaSeedNode' and seed.resolvedType.kind == 'numberTypeNode' %}
+              &{{ seed.name | snakeCase }}.{{ 'to_le_bytes' if seed.resolvedType.endian == 'le' else 'to_be_bytes' }}(),
             {% else %}
               {{ seed.name | snakeCase }}.to_string().as_ref(),
             {% endif %}
@@ -104,6 +106,8 @@ impl {{ account.name | pascalCase }} {
               {{ seed.name | snakeCase }}.as_ref(),
             {% elif seed.kind == 'variablePdaSeedNode' and seed.resolvedType.kind == 'bytesTypeNode' %}
               &{{ seed.name | snakeCase }},
+            {% elif seed.kind == 'variablePdaSeedNode' and seed.resolvedType.kind == 'numberTypeNode' %}
+              &{{ seed.name | snakeCase }}.{{ 'to_le_bytes' if seed.resolvedType.endian == 'le' else 'to_be_bytes' }}(),
             {% else %}
               {{ seed.name | snakeCase }}.to_string().as_ref(),
             {% endif %}

--- a/test/accountsPage.test.ts
+++ b/test/accountsPage.test.ts
@@ -51,6 +51,40 @@ test('it renders a byte array seed used on an account', () => {
     ]);
 });
 
+test('it renders a numeric seed as little-endian bytes', () => {
+    // Given the following program with 1 account and 1 pda with a numeric seed.
+    const node = programNode({
+        accounts: [
+            accountNode({
+                name: 'testAccount',
+                pda: pdaLinkNode('testPda'),
+            }),
+        ],
+        name: 'splToken',
+        pdas: [
+            // Numeric (u64) seed.
+            pdaNode({
+                name: 'testPda',
+                seeds: [variablePdaSeedNode('nonce', numberTypeNode('u64'))],
+            }),
+        ],
+        publicKey: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    });
+
+    // When we render it.
+    const renderMap = visit(node, getRenderMapVisitor());
+
+    // Then the seed is encoded via its little-endian bytes, matching how the
+    // program derives the address, not via its decimal string.
+    codeContains(getFromRenderMap(renderMap, 'accounts/test_account.rs').content, [
+        `nonce: u64,`,
+        `&nonce.to_le_bytes(),`,
+    ]);
+    codeDoesNotContains(getFromRenderMap(renderMap, 'accounts/test_account.rs').content, [
+        `nonce.to_string().as_ref(),`,
+    ]);
+});
+
 test('it renders an empty array of seeds for seedless PDAs', () => {
     // Given the following program with 1 account and 1 pda with empty seeds.
     const node = programNode({


### PR DESCRIPTION
For a numeric PDA seed, `find_pda`/`create_pda` fell through to a catch-all that emitted `.to_string().as_ref()`, so the generated client derived its address from the ASCII decimal instead of the little-endian bytes the program uses. The two never match and the helper is unusable.

Numeric seeds now render as `&seed.to_le_bytes()` (or `to_be_bytes`, following the seed's endianness), matching the constant-seed path and `renderers-js`. Added a unit test and a changeset.

Fixes #101